### PR TITLE
Session Persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
     "test": "pulp test"
   },
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "aws-sdk": "^2.177.0"
+  }
 }

--- a/src/Dynamo.js
+++ b/src/Dynamo.js
@@ -1,0 +1,66 @@
+'use strict'
+const DynamoDB = require('aws-sdk/clients/dynamodb')
+exports._getClient = function (options) {
+    return new DynamoDB.DocumentClient(options)
+}
+
+exports._loadRecord = function (dynamodb) {
+    return function (tableName) {
+        return function (key) {
+            return function (onError, onSuccess) {
+                dynamodb.get({
+                    TableName: tableName,
+                    Key: key
+                }, function (err, data) {
+                    if (err) {
+                        return onError(err)
+                    }
+                    return onSuccess(data)
+                })
+                return function canceler() {
+
+                }
+            }
+        }
+    }
+}
+
+exports._saveRecord = function (dynamodb) {
+    return function (tableName) {
+        return function (item) {
+            return function (onError, onSuccess) {
+                dynamodb.put({
+                    TableName: tableName,
+                    Item: item
+                }, function (err) {
+                    if (err) return onError()
+
+                    return onSuccess()
+                })
+                // TODO?
+                return function canceler() {
+                }
+            }
+        }
+    }
+}
+
+exports._deleteRecord = function (dynamodb) {
+    return function (tableName) {
+        return function (key) {
+            return function (onError, onSuccess) {
+                dynamodb.delete({
+                    TableName: tableName,
+                    Key: key
+                }, function (err) {
+                    if (err) return onError()
+
+                    return onSuccess()
+                })
+                // TODO?
+                return function canceler() {
+                }
+            }
+        }
+    }
+}

--- a/src/Dynamo.purs
+++ b/src/Dynamo.purs
@@ -1,0 +1,44 @@
+module AWS.DynamoDB where
+
+import Prelude
+
+import Control.Monad.Aff (Aff)
+import Control.Monad.Aff.Compat (EffFnAff, fromEffFnAff)
+import Control.Monad.Eff (kind Effect)
+import Data.Foreign (Foreign)
+import Data.Maybe (Maybe)
+import Simple.JSON (write)
+
+type DynamoOptions =
+  { region :: String
+  , endpoint :: Maybe String
+  , apiVersion :: Maybe String
+  }
+
+foreign import data DYNAMO :: Effect
+foreign import data DynamoClient :: Type
+foreign import _getClient :: Foreign → DynamoClient
+
+getClient :: DynamoOptions → DynamoClient
+getClient opts = _getClient (write opts)
+
+foreign import _loadRecord :: ∀ e. DynamoClient → String → Foreign → EffFnAff (dynamo :: DYNAMO | e) Foreign
+
+loadRecord :: ∀ e. DynamoClient → String → Foreign → Aff (dynamo :: DYNAMO | e) Foreign
+loadRecord client tableName key =
+  _loadRecord client tableName key
+    # fromEffFnAff
+
+foreign import _saveRecord :: ∀ e. DynamoClient → String → Foreign → EffFnAff (dynamo :: DYNAMO | e) Unit
+
+saveRecord :: ∀ e. DynamoClient → String → Foreign → Aff (dynamo :: DYNAMO | e) Unit
+saveRecord client tableName record =
+  _saveRecord client tableName record
+    # fromEffFnAff
+
+foreign import _deleteRecord :: ∀ e. DynamoClient → String → Foreign → EffFnAff (dynamo :: DYNAMO | e) Unit
+
+deleteRecord :: ∀ e. DynamoClient → String → Foreign → Aff (dynamo :: DYNAMO | e) Unit
+deleteRecord client tableName key =
+  _deleteRecord client tableName key 
+    # fromEffFnAff

--- a/test/Main.js
+++ b/test/Main.js
@@ -3,6 +3,20 @@ exports.log = function (s) {
         console.log(s)
     }
 }
+
+exports.lambdaTest = function () {
+    const DynamoDB = require('aws-sdk/clients/dynamodb')
+    const client = new DynamoDB.DocumentClient({
+        region: "us-east-1"
+    })
+    client.get({
+        Key: { userId : "yikes"},
+        TableName: "secretword__Sessions"
+    }, function (err, data) {
+        console.log(err, data)
+    })
+}
+
 exports.test1 = {
   "session": {
     "new": false,
@@ -10,7 +24,7 @@ exports.test1 = {
     "application": {
       "applicationId": "amzn1.ask.skill.fe3eeb2f-f7eb-4be5-bcd6-076532ec60cb"
     },
-    "attributes": {},
+    "attributes": null,
     "user": {
       "userId": "foobar"
     }
@@ -42,4 +56,52 @@ exports.test1 = {
     }
   },
   "version": "1.0"
+}
+
+exports.test2 = {
+	"version": "1.0",
+	"session": {
+		"new": true,
+		"sessionId": "amzn1.echo-api.session.f9703fd5-2abc-4c6b-9505-94b8be6e916c",
+		"application": {
+			"applicationId": "amzn1.ask.skill.fe3eeb2f-f7eb-4be5-bcd6-076532ec60cb"
+		},
+		"user": {
+			"userId": "amzn1.ask.account.AEDCFKJK7QX3JRSZSUZC5WBYB5M3DKNVIP7EQLMC5EHHMUXTJZMV4NR2AWBP4N57NCUHY27KQ4KAAOUPEYAQLW46EUNZWB7U2CKBXY74GYPQP6MSAS3XIPJ2CUCVWW4WMH246GSM5DQHK3EZ5Z56FQBZMF6CR7P2JHGXXIJOQ7ZZ4BJAU3R6JUAPN3NCZTQHRGWZV4JV6VU6ODA"
+		}
+	},
+	"context": {
+		"AudioPlayer": {
+			"playerActivity": "IDLE"
+		},
+		"Display": {
+			"token": ""
+		},
+		"System": {
+			"application": {
+				"applicationId": "amzn1.ask.skill.fe3eeb2f-f7eb-4be5-bcd6-076532ec60cb"
+			},
+			"user": {
+				"userId": "amzn1.ask.account.AEDCFKJK7QX3JRSZSUZC5WBYB5M3DKNVIP7EQLMC5EHHMUXTJZMV4NR2AWBP4N57NCUHY27KQ4KAAOUPEYAQLW46EUNZWB7U2CKBXY74GYPQP6MSAS3XIPJ2CUCVWW4WMH246GSM5DQHK3EZ5Z56FQBZMF6CR7P2JHGXXIJOQ7ZZ4BJAU3R6JUAPN3NCZTQHRGWZV4JV6VU6ODA"
+			},
+			"device": {
+				"deviceId": "amzn1.ask.device.AHRNQO36Z62F3GKSE7JGEUYAFJ74XZZ2YZKT2UZIRJXYN6BUJOZO6PE7TLJQ3ZPZ25CUCMBGA2EJYFVGL5E5BPNAP76OLHR53IOJ2BLESJGBA3MK3BXNB4W6PR23UOZ2N7R4L2Q2472NRMCU2B3BMSJCRQRA",
+				"supportedInterfaces": {
+					"AudioPlayer": {},
+					"Display": {
+						"templateVersion": "1.0",
+						"markupVersion": "1.0"
+					}
+				}
+			},
+			"apiEndpoint": "https://api.amazonalexa.com",
+			"apiAccessToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjEifQ.eyJhdWQiOiJodHRwczovL2FwaS5hbWF6b25hbGV4YS5jb20iLCJpc3MiOiJBbGV4YVNraWxsS2l0Iiwic3ViIjoiYW16bjEuYXNrLnNraWxsLmZlM2VlYjJmLWY3ZWItNGJlNS1iY2Q2LTA3NjUzMmVjNjBjYiIsImV4cCI6MTUxNTM3MTg3MywiaWF0IjoxNTE1MzY4MjczLCJuYmYiOjE1MTUzNjgyNzMsInByaXZhdGVDbGFpbXMiOnsiY29uc2VudFRva2VuIjpudWxsLCJkZXZpY2VJZCI6ImFtem4xLmFzay5kZXZpY2UuQUhSTlFPMzZaNjJGM0dLU0U3SkdFVVlBRko3NFhaWjJZWktUMlVaSVJKWFlONkJVSk9aTzZQRTdUTEpRM1pQWjI1Q1VDTUJHQTJFSllGVkdMNUU1QlBOQVA3Nk9MSFI1M0lPSjJCTEVTSkdCQTNNSzNCWE5CNFc2UFIyM1VPWjJON1I0TDJRMjQ3Mk5STUNVMkIzQk1TSkNSUVJBIiwidXNlcklkIjoiYW16bjEuYXNrLmFjY291bnQuQUVEQ0ZLSks3UVgzSlJTWlNVWkM1V0JZQjVNM0RLTlZJUDdFUUxNQzVFSEhNVVhUSlpNVjROUjJBV0JQNE41N05DVUhZMjdLUTRLQUFPVVBFWUFRTFc0NkVVTlpXQjdVMkNLQlhZNzRHWVBRUDZNU0FTM1hJUEoyQ1VDVldXNFdNSDI0NkdTTTVEUUhLM0VaNVo1NkZRQlpNRjZDUjdQMkpIR1hYSUpPUTdaWjRCSkFVM1I2SlVBUE4zTkNaVFFIUkdXWlY0SlY2VlU2T0RBIn19.Y_k6yWl_GPCb1dlwnnA3DcAKJNifJG6MRaFwHCz8-Ng7X8eBYI-irQVlOie9zA6SsdJM5X5lrLneWg5FAE5ukju_49SPXGQWuFHoOmGDCvPQV2rOHehte3TicBh0jMHMY3RJlHue3vIvIMPYhnelvuY96BX6QbCiTY8qSq607-SuvxJZtfs3U7W35Kr-zUaIMvp1EcRb9Voic45MOrFBy4p9shH5IdVdBRV7Fl9wVd6Jq5wn5JFcF0cuoUDsCBDbkUXHv9ePe3TYOx0Wd3Q_xbQkLJQSBzGPhFDzuf_CL-xhbGHR9QxrosDwdoc3sU1-_dDnWB3XI6fUZIpcwJEbAA"
+		}
+	},
+	"request": {
+		"type": "LaunchRequest",
+		"requestId": "amzn1.echo-api.request.8d5730f6-0e10-4682-be13-153823b630b9",
+		"timestamp": "2018-01-07T23:37:53Z",
+		"locale": "en-US"
+	}
 }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,16 +2,37 @@ module Test.Main where
 
 import Prelude
 
-import Control.Monad.Aff (launchAff)
+import AWS.DynamoDB (DYNAMO)
+import Control.Monad.Aff (Fiber, launchAff)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (CONSOLE)
+import Control.Monad.Eff.Random (RANDOM)
 import Data.Foreign (Foreign)
 import Main (myHandler)
 
 foreign import test1 :: Foreign
+foreign import test2 :: Foreign
 foreign import log :: ∀ e. Foreign → Eff (console :: CONSOLE | e) Unit
 
+foreign import lambdaTest :: ∀ e. Eff (console :: CONSOLE | e) Unit
+
+main :: forall t8.
+   Eff
+     ( dynamo :: DYNAMO
+     , console :: CONSOLE
+     , random :: RANDOM
+     | t8
+     )
+     (Fiber
+        ( dynamo :: DYNAMO
+        , console :: CONSOLE
+        , random :: RANDOM
+        | t8
+        )
+        Unit
+     )
 main = launchAff $ do
-  result <- myHandler test1 test1
-  liftEff $ log result
+  myHandler test1 test1 >>= (liftEff <<< log)
+  myHandler test2 test2 >>= (liftEff <<< log)
+  --liftEff lambdaTest


### PR DESCRIPTION
On a SessionEnded request from Amazon, the user's session should be persisted in DynamoDB. The session should be wiped when a game is finished either by victory or by giving up.

Then, on a LaunchRequest, if a session has been saved to DynamoDB, the user should be queried if they want to restore their previous session. If yes, then the current session should be set equal to the previous session. If no, then the session should be wiped and a new game should be started.

As part of this, instead of having "givingUp" as a boolean, the session now has a variable called "Status", which basically encodes the context of what "yes" or "no" means.

Normal - "yes" or "no" don't make any sense
GivingUp - "yes" means I want to give up. "no" means I don't want to give up
Loading - "yes" means pick up from my old session, "no" means start a new game.
  